### PR TITLE
Handle signup response and navigation

### DIFF
--- a/samepath-app/services/ApiService.ts
+++ b/samepath-app/services/ApiService.ts
@@ -6,7 +6,7 @@ export const login = (email: string, password: string) =>
   axios.post(`${API_BASE}/login`, { email, password });
 
 export const signup = (first_name: string, last_name: string, email: string, password: string, school: string) =>
-  axios.post(`${API_BASE}/signup`, { first_name, last_name, email, password, school });
+  axios.post(`${API_BASE}/signup?first_name=${encodeURIComponent(first_name)}&last_name=${encodeURIComponent(last_name)}&email=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}&school=${encodeURIComponent(school)}`);
 
 export const getAvailableCourses = (user_id: number) =>
   axios.get(`${API_BASE}/available_courses`, {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Change signup API call to send parameters as query parameters because the backend expects them in the URL.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation sent signup data in the request body, but the API server returned errors indicating it expected parameters in the URL's query string (e.g., `loc: ["query", "first_name"]`), leading to null values.

---

[Open in Web](https://cursor.com/agents?id=bc-e63bf183-245f-4ebd-8b0b-1f2639984188) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e63bf183-245f-4ebd-8b0b-1f2639984188) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)